### PR TITLE
Non-restrictive days-ahead for relative queries

### DIFF
--- a/docs/userguide/instances.rst
+++ b/docs/userguide/instances.rst
@@ -181,10 +181,16 @@ and Tuesday's forecast for Wednesday, and so on.
 Energy Quantified's API has solved this by via an operation we call *relative
 forecasts*.
 
-The relative forecasts work for **1-10 days ahead**. You *must* filter on the
-**tag**, and you *can* filter on the **time-of-day** the forecast was issued.
-When there isn't any forecast issued for a specific day, then that day will
-have no values.
+The relative forecasts work for **0 or more days ahead**:
+
+   - ``days_ahead=0`` means forecasts for intraday
+   - ``days_ahead=1`` means forecasts for day ahead
+   - ``days_ahead=2`` means forecasts for day after day ahead
+   - `... and so on`
+
+You *must* filter on the **tag**, and you *can* filter on the **time-of-day**
+the forecast was issued. When there isn't any forecast issued for a specific
+day, then that day will have no values.
 
    >>> from datetime import datetime, time
    >>> day_ahead_forecast = eq.instances.relative(
@@ -192,7 +198,7 @@ have no values.
    >>>    begin=datetime(2020, 6, 1, 0, 0, 0),
    >>>    end=datetime(2020, 6, 5, 0, 0, 0),
    >>>    tag='ec',
-   >>>    days_ahead=1,  # The day-ahead forecast (1-10 allowed)
+   >>>    days_ahead=1,  # The day-ahead forecast (0 or higher allowed)
    >>>    time_of_day=time(0, 0),  # Issued at exactly 00:00
    >>>    frequency=Frequency.P1D
    >>> )

--- a/energyquantified/api/instances.py
+++ b/energyquantified/api/instances.py
@@ -312,7 +312,9 @@ class InstancesAPI(BaseAPI):
         them together and return a continuous time series.
 
         By default, this method selects the day-ahead instances (forecasts),
-        but you can set ``days_ahead`` to anything between 1 and 10.
+        but you can set ``days_ahead`` to 0 or higher. 0 means intraday,
+        1 means the day-ahead (default), 2 means the day after day-ahead,
+        and so on.
 
         You may control the time of the day the instance is issued by setting
         exactly one of the follow parameters: ``time_of_day``,
@@ -327,7 +329,8 @@ class InstancesAPI(BaseAPI):
         :type begin: date, datetime, str, required
         :param end: The end date-time
         :type end: date, datetime, str, required
-        :param days_ahead: The number of leading days (1-10), defaults to 1
+        :param days_ahead: The number of leading days (0 or higher),\
+            defaults to 1
         :type days_ahead: int, optional
         :param issued: Whether to select the earliest or latest matching\
             instance per day, allowed values "earliest" | "latest",\
@@ -362,7 +365,7 @@ class InstancesAPI(BaseAPI):
         self._add_datetime(params, "begin", begin, required=True)
         self._add_datetime(params, "end", end, required=True)
         self._add_str(params, "tag", tag, required=True)
-        self._add_int(params, "days-ahead", days_ahead, min=1, max=10, required=True)
+        self._add_int(params, "days-ahead", days_ahead, min=0, max=10000, required=True)
         self._add_str(params, "issued", issued, allowed_values=['earliest', 'latest'], required=True)
         self._add_time(params, "time-of-day", time_of_day)
         self._add_time(params, "after-time-of-day", after_time_of_day)


### PR DESCRIPTION
Increase `days-ahead` parameter constraints for relative queries from 1-10 to 0-10000.