### PR TITLE
Add Periodseries#print() method

### DIFF
--- a/energyquantified/data/periodseries.py
+++ b/energyquantified/data/periodseries.py
@@ -297,6 +297,21 @@ class Periodseries(Series):
             data=data
         )
 
+    def print(self, file=sys.stdout):
+        """
+        Utility method to print a period-based series to any file handle
+        (defaults to stdout).
+        """
+        print(f"Periodseries:", file=file)
+        if self.curve:
+            print(f"  Curve: {repr(self.curve)}", file=file)
+        if self.instance:
+            print(f"  Instance: {self.instance}", file=file)
+        print(f"  Resolution: {self.resolution}", file=file)
+        print(f"", file=file)
+        for d in self.data:
+            d.print(file=file)
+
 
 class _PeriodsToTimeseriesIterator:
     """


### PR DESCRIPTION
Add a `print()` method to the `Periodseries` implementation.

Closes #4.