### PR TITLE
Add single_level_header param on to_dataframe()

### DIFF
--- a/docs/userguide/instances.rst
+++ b/docs/userguide/instances.rst
@@ -40,7 +40,8 @@ The return type from ``load()`` is a
 built-in list. It has extra validations so that all time series in the list have
 the same frequency (hourly, daily, etc.), and it has a method called
 :py:meth:`~energyquantified.data.TimeseriesList.to_dataframe` which converts the
-list of time series to a ``pandas.DataFrame``.
+list of time series to a ``pandas.DataFrame``. See the chapter on
+:doc:`Pandas integration <pandas>` for more details.
 
 Notice that each time series in the list has an ``instance`` attribute (with
 ``issued`` (issue date) and ``tag``). This is what identifies the instances

--- a/docs/userguide/pandas.rst
+++ b/docs/userguide/pandas.rst
@@ -20,8 +20,11 @@ You can convert any of these types to a ``pandas.DataFrame``:
  * :py:class:`~energyquantified.data.Periodseries`
  * :py:class:`~energyquantified.data.OHLCList`
 
-They all have a method called ``to_dataframe()``. ``Periodseries`` differ from
+They all have a method called ``to_dataframe()``. ``Periodseries`` differs from
 the two others in which you must supply a **frequency** parameter.
+
+There also exists an alias of ``to_dataframe()`` called ``to_df()``. The term
+``df`` is a commonly used shorthand and variable name for ``DataFrame``'s.
 
 Convert time series
 ^^^^^^^^^^^^^^^^^^^
@@ -291,6 +294,54 @@ forecasts, for example, have 51 scenarios, named from ``e00``, ``e01``, ...,
 ``e49``, ``e50``. Climate series uses underlying weather years. These column
 headers are named after the weather year they are based on: ``y1980``,
 ``y1981``, ..., ``y2018``, ``y2019``.
+
+
+Force single-level column headers
+---------------------------------
+
+While the default behaviour is to create three levels of column headers,
+as seen above, you can tell the client to merge all the levels into one.
+
+Do this by setting the parameter ``single_level_header=True`` when
+you invoke ``to_dataframe()``.
+
+Using the wind forecast example from earlier on this page:
+
+>>> forecast.instance
+<Instance: issued="2020-10-26 00:00:00+00:00", tag="ec-ens", scenarios=51>
+>>> df = forecast.to_dataframe(name='wind forecast')
+>>> df
+                                    wind forecast                                ...
+                          2020-10-26 00:00 ec-ens                                ...
+                                                        e00       e01       e02  ...       e47       e48       e49       e50
+date                                                                             ...
+2020-10-27 00:00:00+01:00                26575.48  26733.56  27500.18  26672.14  ...  24269.32  24301.24  30265.62  24280.31
+2020-10-28 00:00:00+01:00                30657.37  30446.78  28420.88  37041.53  ...  28426.01  27353.77  32797.71  28044.18
+2020-10-29 00:00:00+01:00                27776.44  27720.31  30748.11  28341.64  ...  30731.12  25900.96  29088.77  28441.85
+2020-10-30 00:00:00+01:00                26984.86  23955.59  32940.16  27493.37  ...  38920.07  34470.99  26831.95  30003.82
+2020-10-31 00:00:00+01:00                15179.69  14326.49  16155.63  16337.56  ...  16874.91  10602.34   8203.10  27192.68
+...
+
+We can add the ``single_level_header`` parameter. Notice that the headers,
+which previously were three levels (curve name, instance and scenario), are
+now merged into one row:
+
+>>> df = forecast.to_dataframe(
+>>>     name='wind forecast',
+>>>     single_level_header=True  # Merge column headers
+>>> )
+                          wind forecast 2020-10-26 00:00 ec-ens wind forecast 2020-10-26 00:00 ec-ens e00  ... wind forecast 2020-10-26 00:00 ec-ens e49 wind forecast 2020-10-26 00:00 ec-ens e50
+date                                                                                                       ...
+2020-10-27 00:00:00+01:00                              26575.48                                  26733.56  ...                                  30265.62                                  24280.31
+2020-10-28 00:00:00+01:00                              30657.37                                  30446.78  ...                                  32797.71                                  28044.18
+2020-10-29 00:00:00+01:00                              27776.44                                  27720.31  ...                                  29088.77                                  28441.85
+2020-10-30 00:00:00+01:00                              26984.86                                  23955.59  ...                                  26831.95                                  30003.82
+2020-10-31 00:00:00+01:00                              15179.69                                  14326.49  ...                                   8203.10                                  27192.68
+...
+
+Some functions and utilities in pandas work best when the ``DataFrame`` has
+a single level header. Setting ``single_level_header=True`` makes it easier
+than if you would have to merge the headers manually.
 
 
 Set custom time series name

--- a/docs/userguide/pandas.rst
+++ b/docs/userguide/pandas.rst
@@ -62,8 +62,11 @@ If you have a scenario-based time series (such as a time series loaded for
 an ensemble forecast), you will get one column per ensemble.
 
 Notice that there are **three column headers** here. The first is the
-**curve**, the second is the **instance**, and the third is the **scenarios**
-– more on this in a section below.
+**curve**, the second is the **instance**, and the third is the **scenarios**.
+You can read more on this in the :ref:`column headers section<column-headers>`
+below. It is also possible to merge these three header levels onto one, see
+the section on :ref:`single-level column headers<single-column-headers>` for
+details.
 
    >>> forecast.instance
    <Instance: issued="2020-10-26 00:00:00+00:00", tag="ec-ens", scenarios=51>
@@ -264,6 +267,8 @@ at different times:
    ...
 
 
+.. _column-headers:
+
 Column headers for time series data
 -----------------------------------
 
@@ -295,6 +300,8 @@ forecasts, for example, have 51 scenarios, named from ``e00``, ``e01``, ...,
 headers are named after the weather year they are based on: ``y1980``,
 ``y1981``, ..., ``y2018``, ``y2019``.
 
+
+.. _single-column-headers:
 
 Force single-level column headers
 ---------------------------------

--- a/docs/userguide/timeseries.rst
+++ b/docs/userguide/timeseries.rst
@@ -166,8 +166,12 @@ a **value**. The **scenarios** attribute is a tuple of the scenario values:
 Convert to pandas
 -----------------
 
+(This section contains a short description on how to convert a time series to a
+``pandas.DataFrame``. See the chapter on :doc:`Pandas integration <pandas>`
+for a detailed explanation.)
+
 Convert :py:class:`~energyquantified.data.Timeseries` objects to pandas by
-calling on :py:meth:`~energyquantified.data.Timeseries.to_dataframe`.
+calling on :py:meth:`~energyquantified.data.Timeseries.to_dataframe`:
 
    >>> from datetime import date
    >>> timeseries = eq.timeseries.load(

--- a/energyquantified/data/periodseries.py
+++ b/energyquantified/data/periodseries.py
@@ -298,7 +298,7 @@ class Periodseries(Series):
         timeseries.set_name(self._name)
         return timeseries
 
-    def to_df(self, frequency=None, name=None):
+    def to_df(self, frequency=None, name=None, single_level_header=False):
         """
         Alias for :meth:`Periodseries.to_dataframe`.
 
@@ -316,13 +316,21 @@ class Periodseries(Series):
         :param name: Set a name for the column in the ``pandas.DataFrame``,\
             defaults to ``value``
         :type name: str, optional
+        :param single_level_header: Set to True to use single-level header \
+            in the DataFrame, defaults to False
+        :type single_level_header: boolean, optional
         :return: A DataFrame
         :rtype: pandas.DataFrame
         :raises ImportError: When pandas is not installed on the system
         """
-        return self.to_dataframe(frequency=frequency, name=name)
+        return self.to_dataframe(
+            frequency=frequency,
+            name=name,
+            single_level_header=single_level_header
+        )
 
-    def to_dataframe(self, frequency=None, name=None):
+    def to_dataframe(self, frequency=None, name=None,
+                     single_level_header=False):
         """
         Convert this period-based to a ``pandas.DataFrame`` as a time series
         in the given frequency.
@@ -338,6 +346,9 @@ class Periodseries(Series):
         :param name: Set a name for the column in the ``pandas.DataFrame``,\
             defaults to ``value``
         :type name: str, optional
+        :param single_level_header: Set to True to use single-level header \
+            in the DataFrame, defaults to False
+        :type single_level_header: boolean, optional
         :return: A DataFrame
         :rtype: pandas.DataFrame
         :raises ImportError: When pandas is not installed on the system
@@ -346,7 +357,10 @@ class Periodseries(Series):
         assert isinstance(frequency, Frequency), "Must be a frequency"
         # Conversion
         timeseries = self.to_timeseries(frequency=frequency)
-        df = timeseries.to_dataframe(name=name)
+        df = timeseries.to_dataframe(
+            name=name,
+            single_level_header=single_level_header
+        )
         return df
 
     def print(self, file=sys.stdout):
@@ -506,7 +520,7 @@ class PeriodseriesList(list):
             for periodseries in self
         )
 
-    def to_df(self, frequency=None):
+    def to_df(self, frequency=None, single_level_header=False):
         """
         Alias for :meth:`Timeseries.to_dataframe`.
 
@@ -516,13 +530,19 @@ class PeriodseriesList(list):
 
         :param frequency: The frequency of the resulting time series'
         :type frequency: Frequency, required
+        :param single_level_header: Set to True to use single-level header \
+            in the DataFrame, defaults to False
+        :type single_level_header: boolean, optional
         :return: A DataFrame
         :rtype: pandas.DataFrame
         :raises ImportError: When pandas is not installed on the system
         """
-        return self.to_dataframe(frequency=frequency)
+        return self.to_dataframe(
+            frequency=frequency,
+            single_level_header=single_level_header
+        )
 
-    def to_dataframe(self, frequency=None):
+    def to_dataframe(self, frequency=None, single_level_header=False):
         """
         Convert this PeriodseriesList to a ``pandas.DataFrame`` where all time
         series are placed in its own column and are lined up with the date-time
@@ -530,6 +550,9 @@ class PeriodseriesList(list):
 
         :param frequency: The frequency of the resulting time series'
         :type frequency: Frequency, required
+        :param single_level_header: Set to True to use single-level header \
+            in the DataFrame, defaults to False
+        :type single_level_header: boolean, optional
         :return: A DataFrame
         :rtype: pandas.DataFrame
         :raises ImportError: When pandas is not installed on the system
@@ -538,7 +561,9 @@ class PeriodseriesList(list):
         assert isinstance(frequency, Frequency), "Must be a frequency"
         # Convert to time series then to data frame
         timeseries_list = self.to_timeseries(frequency=frequency)
-        return timeseries_list.to_dataframe()
+        return timeseries_list.to_dataframe(
+            single_level_header=single_level_header
+        )
 
     def append(self, periodseries):
         _validate_periodseries(periodseries)

--- a/energyquantified/data/timeseries.py
+++ b/energyquantified/data/timeseries.py
@@ -405,30 +405,43 @@ class Timeseries(Series):
         else:
             raise ValueError("Timeseries has no values")
 
-    def to_df(self, name=None):
+    def to_df(self, name=None, single_level_header=False):
         """
         Alias for :meth:`Timeseries.to_dataframe`. Convert this timeseries
         to a ``pandas.DataFrame``.
 
         :param name: Set a name for the value column, defaults to ``value``
         :type name: str, optional
+        :param single_level_header: Set to True to use single-level header \
+            in the DataFrame, defaults to False
+        :type single_level_header: boolean, optional
         :return: A DataFrame
         :rtype: pandas.DataFrame
         :raises ImportError: When pandas is not installed on the system
         """
-        return self.to_dataframe(name=name)
+        return self.to_dataframe(
+            name=name,
+            single_level_header=single_level_header
+        )
 
-    def to_dataframe(self, name=None):
+    def to_dataframe(self, name=None, single_level_header=False):
         """
         Convert this timeseries to a ``pandas.DataFrame``.
 
         :param name: Set a name for the value column, defaults to ``value``
         :type name: str, optional
+        :param single_level_header: Set to True to use single-level header \
+            in the DataFrame, defaults to False
+        :type single_level_header: boolean, optional
         :return: A DataFrame
         :rtype: pandas.DataFrame
         :raises ImportError: When pandas is not installed on the system
         """
-        return timeseries_to_dataframe(self, name=name)
+        return timeseries_to_dataframe(
+            self,
+            name=name,
+            single_level_header=single_level_header
+        )
 
     def validate(self):
         """
@@ -501,7 +514,7 @@ class TimeseriesList(list):
     def frequency(self):
         return self._frequency
 
-    def to_df(self):
+    def to_df(self, single_level_header=False):
         """
         Alias for :meth:`Timeseries.to_dataframe`.
 
@@ -509,23 +522,32 @@ class TimeseriesList(list):
         series are placed in its own column and are lined up with the date-time
         as index.
 
+        :param single_level_header: Set to True to use single-level header \
+            in the DataFrame, defaults to False
+        :type single_level_header: boolean, optional
         :return: A DataFrame
         :rtype: pandas.DataFrame
         :raises ImportError: When pandas is not installed on the system
         """
-        return self.to_dataframe()
+        return self.to_dataframe(single_level_header=single_level_header)
 
-    def to_dataframe(self):
+    def to_dataframe(self, single_level_header=False):
         """
         Convert this TimeseriesList to a ``pandas.DataFrame`` where all time
         series are placed in its own column and are lined up with the date-time
         as index.
 
+        :param single_level_header: Set to True to use single-level header \
+            in the DataFrame, defaults to False
+        :type single_level_header: boolean, optional
         :return: A DataFrame
         :rtype: pandas.DataFrame
         :raises ImportError: When pandas is not installed on the system
         """
-        return timeseries_list_to_dataframe(self)
+        return timeseries_list_to_dataframe(
+            self,
+            single_level_header=single_level_header
+        )
 
     def append(self, timeseries):
         # Asserts


### PR DESCRIPTION
Closes #20.

- [x] Add param `single_level_header` on all `to_dataframe()` and `to_df()` methods.
- [x] Documentation: Add section in pandas chapter on column headers
- [x] Documentation: Add link to column header part from the other parts of the pandas examples in the documentation
