### PR TITLE
Use latest requests 2.x and python-dateutil 2.8.x by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@ Changelog
 =========
 
 
+dev
+---
+
+**Dependencies**
+
+- ``requests``: Use the latest v2.x available, as requests is very stable library.
+- ``python-dateutil``: Use the latest v2.8.x available.
+
+
 0.8
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ Sphinx==3.3.1
 docutils==0.17
 pytz
 tzlocal
-requests>2.3,<3
-python-dateutil>=2.8.1,<2.9
+requests>=2.3,<3
+python-dateutil>=2.8.0,<2.9
 recommonmark==0.6.0
 wheel
 twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ Sphinx==3.3.1
 docutils==0.17
 pytz
 tzlocal
-requests==2.25.1
-python-dateutil==2.8.1
+requests>2.3,<3
+python-dateutil>=2.8.1,<2.9
 recommonmark==0.6.0
 wheel
 twine

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 # Requirements
 install_requires = [
-    "requests==2.25.1",
+    "requests>=2.3,<3",
     "pytz",
     "tzlocal",
-    "python-dateutil==2.8.1",
+    "python-dateutil>=2.8.1,<2.9",
 ]
 # tests_require = [
 #     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     "requests>=2.3,<3",
     "pytz",
     "tzlocal",
-    "python-dateutil>=2.8.1,<2.9",
+    "python-dateutil>=2.8.0,<2.9",
 ]
 # tests_require = [
 #     "pytest",


### PR DESCRIPTION
Closes #47. Update the library dependencies. We will use the following versions:

- The latest 2.x version of requests
- The latest 2.8.x version of python-dateutil
