### PR TITLE
single_level_header=True no longer creates MultiIndex

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@ Changelog
 =========
 
 
+dev
+---
+
+**Bugfixes**
+
+- When invoking ``timeseries.to_dataframe(single_level_header=True)`` the
+  resulting column index was still a ``MultiIndex`` but with a single level.
+  Now the resulting column index is a normal ``Index`` type.
+
+
 0.8.1
 -----
 

--- a/energyquantified/utils/pandas.py
+++ b/energyquantified/utils/pandas.py
@@ -203,13 +203,9 @@ def _timeseries_to_dataframe_value_single_header(timeseries, name,
     # Column header
     if include_instance:
         instance = timeseries.instance_or_contract_dataframe_column_header()
-        columns = [
-            [f"{name} {instance}".strip()]
-        ]
+        columns = [f"{name} {instance}".strip()]
     else:
-        columns = [
-            [name]
-        ]
+        columns = [name]
     # Convert a time series of (date, value)
     df = pd.DataFrame.from_records(
         ((v.value,) for v in timeseries),
@@ -273,17 +269,13 @@ def _timeseries_to_dataframe_scenarios_single_header(timeseries, name,
     if include_instance:
         instance = timeseries.instance_or_contract_dataframe_column_header()
         columns = [
-            [
-                f"{name} {instance} {scenario}".strip()
-                for scenario in timeseries.scenario_names
-            ],
+            f"{name} {instance} {scenario}".strip()
+            for scenario in timeseries.scenario_names
         ]
     else:
         columns = [
-            [
-                f"{name} {scenario}".strip()
-                for scenario in timeseries.scenario_names
-            ],
+            f"{name} {scenario}".strip()
+            for scenario in timeseries.scenario_names
         ]
     # Convert a time series of (date, scenarios[])
     df = pd.DataFrame.from_records(
@@ -349,14 +341,12 @@ def _timeseries_to_dataframe_mean_and_scenarios_single_header(timeseries, name,
     if include_instance:
         instance = timeseries.instance_or_contract_dataframe_column_header()
         columns = [
-            [
-                f"{name} {instance} {scenario}".strip()
-                for scenario in scenario_names
-            ],
+            f"{name} {instance} {scenario}".strip()
+            for scenario in scenario_names
         ]
     else:
         columns = [
-            [f"{name} {scenario}".strip() for scenario in scenario_names],
+            f"{name} {scenario}".strip() for scenario in scenario_names
         ]
     # Convert a time series of (date, scenarios[])
     df = pd.DataFrame.from_records(


### PR DESCRIPTION
Closes #49 

**Background**

From the documentation it seems like the expected output from `df.columns` should be a single level column index, however the output is a single-entry `MultiIndex`.

**Tasks**

- [x] Fix bug in pandas conversion
- [x] Update changelog