### PR TITLE
Bugfix empty push feed #101

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ dev
 
 **Bugfixes**
 
-- Remove code setting log level to ``DEBUG``
+- Remove code setting default log level to ``DEBUG``
+- Fix a bug introduced in v0.12 that caused parsing of curve events to fail
 
 
 0.12

--- a/energyquantified/api/events.py
+++ b/energyquantified/api/events.py
@@ -47,6 +47,7 @@ from energyquantified.events.callback import (
 from energyquantified.events.connection_event import TIMEOUT
 
 
+logging.basicConfig(stream=sys.stderr)
 log = logging.getLogger(__name__)
 
 

--- a/energyquantified/parser/metadata.py
+++ b/energyquantified/parser/metadata.py
@@ -192,8 +192,12 @@ def parse_subscription(json):
     """
     Parse a JSON response from the server into a Subscription object.
     """
-    access = SubscriptionAccess.by_tag(json.get("access"))
-    stype = SubscriptionType.by_tag(json.get("type"))
+    access = json.get("access")
+    if access is not None:
+        access = SubscriptionAccess.by_tag(access)
+    stype = json.get("type")
+    if stype is not None:
+        stype = SubscriptionType.by_tag(stype)
     label = json.get("label")
     package = (
         json.get("package")


### PR DESCRIPTION
* Add default logging (ignored if logging handlers configured by user), closes #101 
* Make parse_subscription() less strict due to invalid format for curves on the stream, closes #101 