### PR TITLE
Filter instances and ensembles by issued time of day #111

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+dev
+---
+
+**Improvements**
+
+- Add ``issued_time_of_day`` parameter to ``eq.instances.list()``,
+  ``eq.instances.load()`` and ``eq.instances.latest()`` for filtering instances
+  based on issued time
+
+
 0.13.5
 ------
 

--- a/docs/userguide/instances.rst
+++ b/docs/userguide/instances.rst
@@ -69,10 +69,10 @@ instances issued in 2018:
 Load only instances issued at a specific time of day by using the
 ``issued-time-of-day`` parameter. You can provide one or more time-values.
 
-   >>> from datetime import time as dtime
+   >>> from datetime import time
    >>> forecasts = eq.instances.load(
    >>>    'DE Wind Power Production MWh/h 15min Forecast',
-   >>>    issued_time_of_day=["12:00", dtime(3,0)] # Issued at 12:00 or 03:00
+   >>>    issued_time_of_day=["12:00", time(3,0)] # Issued at 12:00 or 03:00
    >>> )
 
 You can also filter by the instance's **tags** you would like to load. It is

--- a/docs/userguide/instances.rst
+++ b/docs/userguide/instances.rst
@@ -66,6 +66,15 @@ instances issued in 2018:
    >>>    issued_at_latest=datetime(2018, 12, 31, 23, 59, 59) # Last second of 2018!
    >>> )
 
+Load only instances issued at a specific time of day by using the
+``issued-time-of-day`` parameter. You can provide one or more time-values.
+
+   >>> from datetime import time as dtime
+   >>> forecasts = eq.instances.load(
+   >>>    'DE Wind Power Production MWh/h 15min Forecast',
+   >>>    issued_time_of_day=["12:00", dtime(3,0)] # Issued at 12:00 or 03:00
+   >>> )
+
 You can also filter by the instance's **tags** you would like to load. It is
 possible to list more than one tag. Let's download data for ``ec`` and ``gfs``:
 
@@ -260,7 +269,7 @@ Aggregations are also supported, as you can see from the examples above.
 
 
 Rolling forecasts (hours-ahead forecasts)
---------------------------------------
+-----------------------------------------
 
 Method reference: :py:meth:`eq.instances.rolling() <energyquantified.api.InstancesAPI.rolling>`
 

--- a/energyquantified/api/base.py
+++ b/energyquantified/api/base.py
@@ -200,6 +200,24 @@ class BaseAPI:
             raise ValidationError(reason="Provide a time", parameter=name)
 
     @staticmethod
+    def _add_time_list(params, name, var, required=False):
+        if (var is None or var == []) and not required:
+            return
+        if not isinstance(var, (list, tuple)):
+            var = [var]
+        for i in range(len(var)):
+            if isinstance(var[i], str):
+                continue
+            elif isinstance(var[i], time):
+                var[i] = var[i].isoformat(timespec='milliseconds')
+            else:
+                raise ValidationError(
+                    reason="Provide a time or a list of times",
+                    parameter=name,
+                )
+        params[name] = list(var)
+
+    @staticmethod
     def _add_str(params, name, var, allowed_values=None, required=False):
         if var is None and not required:
             return

--- a/energyquantified/api/instances.py
+++ b/energyquantified/api/instances.py
@@ -50,7 +50,9 @@ class InstancesAPI(BaseAPI):
             exlude_tags=None,
             limit=25,
             issued_at_latest=None,
-            issued_at_earliest=None):
+            issued_at_earliest=None,
+            issued_time_of_day=None,
+        ):
         """
         List instances for the curve. Does not load any time series data.
 
@@ -75,6 +77,8 @@ class InstancesAPI(BaseAPI):
         :type issued_at_latest: datetime, date, str, optional
         :param issued_at_earliest: Filter by issue date, defaults to None
         :type issued_at_earliest: datetime, date, str, optional
+        :param issued_time_of_day: Filter by issued time of day, defaults to None
+        :type issued_time_of_day: list, time, str, optional
         :return: A list of :py:class:`energyquantified.metadata.Instance`
         :rtype: list
         """
@@ -88,6 +92,7 @@ class InstancesAPI(BaseAPI):
         self._add_int(params, "limit", limit, min=1, max=25, required=True)
         self._add_datetime(params, "issued-at-latest", issued_at_latest)
         self._add_datetime(params, "issued-at-earliest", issued_at_earliest)
+        self._add_time_list(params, "issued-time-of-day", issued_time_of_day)
         # HTTP request
         response = self._get(url, params=params)
         return parse_instance_list(response.json())
@@ -100,6 +105,7 @@ class InstancesAPI(BaseAPI):
             limit=5,
             issued_at_latest=None,
             issued_at_earliest=None,
+            issued_time_of_day=None,
             time_zone=None,
             frequency=None,
             aggregation=None,
@@ -133,10 +139,12 @@ class InstancesAPI(BaseAPI):
         :type exlude_tags: list, str, optional
         :param limit: Maximum number of instances returned, defaults to 5
         :type limit: int, optional
-        :param issued_at_latest: [description], defaults to None
-        :type issued_at_latest: [type], optional
-        :param issued_at_earliest: [description], defaults to None
-        :type issued_at_earliest: [type], optional
+        :param issued_at_latest: Filter by issue date, defaults to None
+        :type issued_at_latest: datetime, date, str, optional
+        :param issued_at_earliest: Filter by issue date, defaults to None
+        :type issued_at_earliest: datetime, date, str, optional
+        :param issued_time_of_day: Filter by issued time of day, defaults to None
+        :type issued_time_of_day: list, str, time, optional
         :param time_zone: Set the timezone for the date-times
         :type time_zone: TzInfo, optional
         :param frequency: Set the preferred frequency for aggregations,\
@@ -176,6 +184,7 @@ class InstancesAPI(BaseAPI):
             self._add_int(params, "limit", limit, min=1, max=10, required=True)
         self._add_datetime(params, "issued-at-latest", issued_at_latest)
         self._add_datetime(params, "issued-at-earliest", issued_at_earliest)
+        self._add_time_list(params, "issued-time-of-day", issued_time_of_day)
         self._add_time_zone(params, "timezone", time_zone, required=False)
         self._add_frequency(params, "frequency", frequency)
         if "frequency" in params:
@@ -192,6 +201,7 @@ class InstancesAPI(BaseAPI):
             curve,
             tags=None,
             issued_at_latest=None,
+            issued_time_of_day=None,
             time_zone=None,
             frequency=None,
             aggregation=None,
@@ -213,8 +223,10 @@ class InstancesAPI(BaseAPI):
         :type curve: :py:class:`energyquantified.metadata.Curve`, str
         :param tags: Filter by instance tags, defaults to None
         :type tags: list, str, optional
-        :param issued_at_latest: [description], defaults to None
-        :type issued_at_latest: [type], optional
+        :param issued_at_latest: Filter by issue date, defaults to None
+        :type issued_at_latest: datetime, date, str, optional
+        :param issued_time_of_day: Filter by issued time of day, defaults to None
+        :type issued_time_of_day: list, str, time, optional
         :param time_zone: Set the timezone for the date-times
         :type time_zone: TzInfo, optional
         :param frequency: Set the preferred frequency for aggregations,\
@@ -249,6 +261,7 @@ class InstancesAPI(BaseAPI):
         params = {}
         self._add_str_list(params, "tags", tags)
         self._add_datetime(params, "issued-at-latest", issued_at_latest)
+        self._add_time_list(params, "issued-time-of-day", issued_time_of_day)
         self._add_time_zone(params, "timezone", time_zone, required=False)
         self._add_frequency(params, "frequency", frequency)
         if "frequency" in params:


### PR DESCRIPTION
* Add `issued-time-of-day` parameter to `eq.instances.list()`, `eq.instances.load()`, and `eq.instances.latest()` #111
* Add helper `_add_time_list()` for parameter parsing (list of time values)
* Minor docstring improvements