### PR TITLE
Upgrade dateutil to 2.9 from 2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ docutils==0.17
 pytz
 tzlocal
 requests>=2.31,<3
-python-dateutil>=2.8.0,<2.9
+python-dateutil>=2.8.0,<=2.9
 recommonmark==0.6.0
 wheel
 twine


### PR DESCRIPTION
The only uses of `dateutil` in this package are calls to the methods
```
dateutil.relativedelta.relativedelta
dateutil.parser.isoparse
```
neither of which are affected by the upgrade dateutil 2.8->2.9, as per the changelog: https://dateutil.readthedocs.io/en/stable/changelog.html#version-2-9-0-2024-02-29

What prompted me to make this change is that my organization uses `eq-python-client` together with `powerbot-client`, and the latter requires `dateutil 2.9`. I imagine others in the industry use the combination of these packages and could benefit from this upgrade.